### PR TITLE
Add Dockerized Spotify podcast downloader service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+# Copy application code
+COPY app /app/app
+WORKDIR /app
+
+EXPOSE 8080
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# podcastsummarizer
+# Podcast Downloader Service
+
+This service exposes an HTTP endpoint to download a Spotify podcast episode as an MP3 file and upload it to Azure Blob Storage.
+
+## Building the Docker image
+
+```bash
+docker build -t podcast-downloader .
+```
+
+## Running the container
+
+```bash
+docker run -e AZURE_STORAGE_ACCOUNT=... \
+           -e AZURE_STORAGE_KEY=... \
+           -e AZURE_CONTAINER_NAME=... \
+           -p 8080:8080 \
+           podcast-downloader
+```
+
+## Example request
+
+```bash
+curl -X POST http://localhost:8080/convert \
+     -H "Content-Type: application/json" \
+     -d '{"url": "https://open.spotify.com/episode/123456"}'
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,73 @@
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from azure.storage.blob import BlobServiceClient
+
+app = FastAPI()
+
+
+class ConvertRequest(BaseModel):
+    url: str
+
+
+SPOTIFY_EPISODE_RE = re.compile(r"^https://open\.spotify\.com/episode/([a-zA-Z0-9]+)")
+
+
+def _get_container_client():
+    account = os.getenv("AZURE_STORAGE_ACCOUNT")
+    key = os.getenv("AZURE_STORAGE_KEY")
+    container = os.getenv("AZURE_CONTAINER_NAME")
+    if not all([account, key, container]):
+        raise HTTPException(status_code=500, detail="Missing Azure Storage configuration")
+    service = BlobServiceClient(
+        account_url=f"https://{account}.blob.core.windows.net", credential=key
+    )
+    return service.get_container_client(container)
+
+
+@app.post("/convert")
+def convert(req: ConvertRequest):
+    match = SPOTIFY_EPISODE_RE.match(req.url)
+    if not match:
+        raise HTTPException(status_code=400, detail="Invalid Spotify episode URL")
+    episode_id = match.group(1)
+
+    try:
+        container_client = _get_container_client()
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cmd = ["spotdl", req.url, "--output", tmpdir, "--format", "mp3"]
+        try:
+            subprocess.run(cmd, check=True, capture_output=True)
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr.decode() if exc.stderr else ""
+            raise HTTPException(status_code=500, detail=f"Download failed: {stderr}")
+
+        mp3_files = list(Path(tmpdir).glob("*.mp3"))
+        if not mp3_files:
+            raise HTTPException(status_code=500, detail="MP3 file not found after download")
+        downloaded = mp3_files[0]
+        final_path = Path(tmpdir) / f"{episode_id}.mp3"
+        downloaded.rename(final_path)
+
+        blob_name = f"{episode_id}.mp3"
+        try:
+            with open(final_path, "rb") as data:
+                container_client.upload_blob(name=blob_name, data=data, overwrite=True)
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=f"Upload failed: {exc}")
+
+    blob_url = (
+        f"https://{os.getenv('AZURE_STORAGE_ACCOUNT')}.blob.core.windows.net/"
+        f"{os.getenv('AZURE_CONTAINER_NAME')}/{blob_name}"
+    )
+    return {"url": blob_url}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+spotdl
+yt-dlp
+azure-storage-blob


### PR DESCRIPTION
## Summary
- add FastAPI service that downloads Spotify episodes and uploads MP3s to Azure Blob Storage
- include Dockerfile installing spotdl and Azure SDK
- document build and runtime usage

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_688f46be1af08331b8508dfa732c19a9