### PR TITLE
Add YouTube transcript summarization webpage

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,11 +2,15 @@ import os
 import re
 import subprocess
 import tempfile
+import json
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 from azure.storage.blob import BlobServiceClient
+from youtube_transcript_api import YouTubeTranscriptApi, NoTranscriptFound
+from openai import OpenAI
 
 app = FastAPI()
 
@@ -15,7 +19,12 @@ class ConvertRequest(BaseModel):
     url: str
 
 
+class SummarizeRequest(BaseModel):
+    url: str
+
+
 SPOTIFY_EPISODE_RE = re.compile(r"^https://open\.spotify\.com/episode/([a-zA-Z0-9]+)")
+YOUTUBE_VIDEO_RE = re.compile(r"(?:v=|be/)([\w-]{11})")
 
 
 def _get_container_client():
@@ -28,6 +37,87 @@ def _get_container_client():
         account_url=f"https://{account}.blob.core.windows.net", credential=key
     )
     return service.get_container_client(container)
+
+
+def _extract_video_id(url: str) -> str:
+    match = YOUTUBE_VIDEO_RE.search(url)
+    if not match:
+        raise HTTPException(status_code=400, detail="Invalid YouTube URL")
+    return match.group(1)
+
+
+def _fetch_transcript(video_id: str) -> str:
+    try:
+        transcript = YouTubeTranscriptApi.get_transcript(video_id)
+    except NoTranscriptFound:
+        raise HTTPException(status_code=404, detail="Transcript not found")
+    return " ".join(t["text"] for t in transcript)
+
+
+def _summarize_text(text: str) -> dict:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=500, detail="Missing OpenAI API key")
+    client = OpenAI(api_key=api_key)
+    prompt = (
+        "Summarize the following transcript. Return JSON with keys 'bullet_points' "
+        "(list of bullet point strings) and 'companies' (list of objects with 'name' "
+        "and 'summary'). Transcript:\n"
+    )
+    completion = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": prompt + text},
+        ],
+        temperature=0.3,
+    )
+    try:
+        return json.loads(completion.choices[0].message.content)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=500, detail="Failed to parse summary response")
+
+
+@app.get("/", response_class=HTMLResponse)
+def index():
+    return """
+    <html>
+      <body>
+        <h1>YouTube Summarizer</h1>
+        <form id='form'>
+          <input type='text' id='url' placeholder='YouTube URL' size='50'/>
+          <button type='submit'>Summarize</button>
+        </form>
+        <div id='result'></div>
+        <script>
+        const form=document.getElementById('form');
+        form.addEventListener('submit', async (e)=>{
+          e.preventDefault();
+          const url=document.getElementById('url').value;
+          const resp=await fetch('/summarize', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({url})});
+          const data=await resp.json();
+          let html='<h2>Summary</h2><ul>';
+          for(const bp of data.bullet_points){html+=`<li>${bp}</li>`;}
+          html+='</ul>';
+          if(data.companies && data.companies.length){
+            html+='<h2>Companies</h2><ul>';
+            for(const c of data.companies){html+=`<li><strong>${c.name}</strong>: ${c.summary}</li>`;}
+            html+='</ul>';
+          }
+          document.getElementById('result').innerHTML=html;
+        });
+        </script>
+      </body>
+    </html>
+    """
+
+
+@app.post("/summarize")
+def summarize(req: SummarizeRequest):
+    video_id = _extract_video_id(req.url)
+    transcript = _fetch_transcript(video_id)
+    result = _summarize_text(transcript)
+    return result
 
 
 @app.post("/convert")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn[standard]
 spotdl
 yt-dlp
 azure-storage-blob
+openai
+youtube-transcript-api


### PR DESCRIPTION
## Summary
- add FastAPI endpoints to fetch YouTube transcript, summarize it with OpenAI, and extract mentioned companies
- serve a simple webpage for entering a YouTube URL and displaying bullet point summaries and company info
- include OpenAI and transcript dependencies

## Testing
- `python -m py_compile app/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890ae40725883318d3677a62b70de64